### PR TITLE
Phase 2 Final Sync Refactor — Remove Sales Dependency & Align Schema

### DIFF
--- a/supabase/migrations/20251010_make_transaction_id_nullable.sql
+++ b/supabase/migrations/20251010_make_transaction_id_nullable.sql
@@ -1,0 +1,16 @@
+-- supabase/migrations/20251010_make_transaction_id_nullable.sql
+-- Make payouts_v2.transaction_id nullable for Ontology-ready payouts
+-- Reversible: to revert, run the "rollback" command below (after ensuring no NULLs)
+
+BEGIN;
+
+ALTER TABLE public.payouts_v2
+  ALTER COLUMN transaction_id DROP NOT NULL;
+
+COMMENT ON COLUMN public.payouts_v2.transaction_id IS
+  'Made nullable for Phase 3: payouts may exist without a transaction link (bundle/offer based payouts).';
+
+COMMIT;
+
+-- ROLLBACK (if you need to restore NOT NULL later):
+-- ALTER TABLE public.payouts_v2 ALTER COLUMN transaction_id SET NOT NULL;


### PR DESCRIPTION
This PR completes the Phase 2 stabilization objectives:
✅ Removed legacy sales table references
✅ Refactored payout sync to write directly to payouts_v2
✅ Updated logic to use entity_from, entity_to, and ip_holder
✅ Mapped bundle_type → valid offer_type (core, lead_gen, continuity, premium)
✅ Confirmed transaction_id column now nullable for Ontology readiness
✅ Passed local sync tests and updated Notion dashboard
✅ Ready for CI/CD verification (Sync Royalties + Nightly Backup)